### PR TITLE
Rename default migrations folder and support optional bundle name

### DIFF
--- a/Command/GenerateCommand.php
+++ b/Command/GenerateCommand.php
@@ -346,11 +346,7 @@ EOT
     protected function getMigrationDirectory($bundleName)
     {
         if (!$bundleName) {
-            return sprintf(
-                '%s/src/%s',
-                $this->getApplication()->getKernel()->getProjectDir(),
-                $this->configResolver->getParameter('ez_migration_bundle.version_directory')
-            );
+            return $this->getApplication()->getKernel()->getProjectDir() . '/src/' . $this->configResolver->getParameter('ez_migration_bundle.version_directory');
         }
 
         // Allow direct usage of a directory path instead of a bundle name

--- a/Command/GenerateCommand.php
+++ b/Command/GenerateCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Yaml\Yaml;
 use Twig\Environment;
 
@@ -67,28 +68,28 @@ class GenerateCommand extends AbstractCommand
             ->setHelp(<<<EOT
 The <info>kaliop:migration:generate</info> command generates a skeleton migration definition file:
 
-    <info>php ezpublish/console kaliop:migration:generate bundleName</info>
+    <info>php ezpublish/console kaliop:migration:generate</info>
 
-You can optionally specify the file type to generate with <info>--format</info>, as well a name for the migration:
+You can optionally specify the file type to generate with <info>--format</info>, bundle name where the migration definition should be created as well a name for the migration:
 
     <info>php ezpublish/console kaliop:migration:generate --format=json bundleName migrationName</info>
 
 For SQL type migration you can optionally specify the database server type the migration is for with <info>--dbserver</info>:
 
-    <info>php ezpublish/console kaliop:migration:generate --format=sql bundleName</info>
+    <info>php ezpublish/console kaliop:migration:generate --format=sql</info>
 
 For content/content_type/language/object_state/role/section migrations you need to specify the entity that you want to generate the migration for:
 
-    <info>php ezpublish/console kaliop:migration:generate --type=content --match-type=content_id --match-value=10,14 --lang=all bundleName</info>
+    <info>php ezpublish/console kaliop:migration:generate --type=content --match-type=content_id --match-value=10,14 --lang=all</info>
 
 For role type migration you will receive a yaml file with the current role definition. You must define ALL the policies
 you wish for the role. Any not defined will be removed. Example for updating an existing role:
 
-    <info>php ezpublish/console kaliop:migration:generate --type=role --mode=update --match-type=identifier --match-value=Anonymous bundleName</info>
+    <info>php ezpublish/console kaliop:migration:generate --type=role --mode=update --match-type=identifier --match-value=Anonymous</info>
 
 For freeform php migrations, you will receive a php class definition
 
-    <info>php ezpublish/console kaliop:migration:generate --format=php bundlename classname</info>
+    <info>php ezpublish/console kaliop:migration:generate --format=php classname</info>
 
 To list all available migration types for generation, as well as the corresponding match-types, run:
 
@@ -121,10 +122,6 @@ EOT
         }
 
         $bundleName = $input->getArgument('bundle');
-        if ($bundleName === null) {
-            // throw same exception as SF would when declaring 'bundle' as mandatory arg
-            throw new \RuntimeException('Not enough arguments (missing: "bundle").');
-        }
         $name = $input->getArgument('name');
         $fileType = $input->getOption('format');
         $migrationType = $input->getOption('type');
@@ -343,11 +340,19 @@ EOT
     }
 
     /**
-     * @param string $bundleName a bundle name or filesystem path to a directory
+     * @param string|null $bundleName a bundle name or filesystem path to a directory
      * @return string
      */
     protected function getMigrationDirectory($bundleName)
     {
+        if (!$bundleName) {
+            return sprintf(
+                '%s/src/%s',
+                $this->getApplication()->getKernel()->getProjectDir(),
+                $this->configResolver->getParameter('ez_migration_bundle.version_directory')
+            );
+        }
+
         // Allow direct usage of a directory path instead of a bundle name
         if (strpos($bundleName, '/') !== false && is_dir($bundleName)) {
             return rtrim($bundleName, '/');

--- a/Core/Loader/Filesystem.php
+++ b/Core/Loader/Filesystem.php
@@ -61,9 +61,16 @@ class Filesystem implements LoaderInterface
      */
     protected function getDefinitions(array $paths = array(), $returnFilename = false)
     {
-        // if no paths defined, we look in all bundles
+        // if no paths defined, we look in default paths
         if (empty($paths)) {
-            $paths = array();
+            $paths = array(
+                sprintf(
+                    '%s/src/%s',
+                    $this->kernel->getProjectDir(),
+                    $this->versionDirectory
+                )
+            );
+
             /** @var $bundle \Symfony\Component\HttpKernel\Bundle\BundleInterface */
             foreach ($this->kernel->getBundles() as $bundle)
             {

--- a/Core/Loader/Filesystem.php
+++ b/Core/Loader/Filesystem.php
@@ -64,11 +64,7 @@ class Filesystem implements LoaderInterface
         // if no paths defined, we look in default paths
         if (empty($paths)) {
             $paths = array(
-                sprintf(
-                    '%s/src/%s',
-                    $this->kernel->getProjectDir(),
-                    $this->versionDirectory
-                )
+                $this->kernel->getProjectDir() . '/src/' . $this->versionDirectory
             );
 
             /** @var $bundle \Symfony\Component\HttpKernel\Bundle\BundleInterface */

--- a/Core/Loader/FilesystemRecursive.php
+++ b/Core/Loader/FilesystemRecursive.php
@@ -13,11 +13,18 @@ class FilesystemRecursive extends Filesystem
 {
     protected function getDefinitions(array $paths = array(), $returnFilename = false)
     {
-        // if no paths defined, we look in all bundles
+        // if no paths defined, we look in default paths
         if (empty($paths)) {
-            $paths = array();
+            $paths = array(
+                sprintf(
+                    '%s/src/%s',
+                    $this->kernel->getProjectDir(),
+                    $this->versionDirectory
+                )
+            );
+
             /** @var $bundle \Symfony\Component\HttpKernel\Bundle\BundleInterface */
-            foreach($this->kernel->getBundles() as $bundle)
+            foreach ($this->kernel->getBundles() as $bundle)
             {
                 $path = $bundle->getPath() . "/" . $this->versionDirectory;
                 if (is_dir($path)) {

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,7 +5,7 @@ parameters:
     # The directory (inside each bundle) where to look for migrations definitions
     # NB: supports per-siteaccess configuration as an override of global configuration. For that, just define parameters:
     #     ez_migration_bundle.<siteaccess_group>.version_directory
-    ez_migration_bundle.version_directory: 'MigrationVersions'
+    ez_migration_bundle.version_directory: 'MigrationsDefinitions'
     # The database tables used to store migration information. Will be created automatically
     # NB: supports per-siteaccess configuration as an override of global configuration. For that, just define parameters:
     #     ez_migration_bundle.<siteaccess_group>.table_name


### PR DESCRIPTION
As bundles are not recommended for Symfony above 4.0, I've made `bundleName` argument optional + added `src` directory lookup + renamed default migration folder